### PR TITLE
修正&优化 行程路线文本

### DIFF
--- a/game.po
+++ b/game.po
@@ -4450,27 +4450,27 @@ msgstr "检测到过时数据，已忽略"
 
 msgctxt "path2_arrive"
 msgid "Arrive at {}"
-msgstr "在 {} 到达"
+msgstr "抵达 {}"
 
 msgctxt "path2_ride"
 msgid "Ride {0} for {1}"
-msgstr "乘坐{0}{1}"
+msgstr "乘坐 {0} · {1}"
 
 msgctxt "path2_take2"
 msgid " Up to {0} [{1}]"
-msgstr "直到 {0} [{1}]"
+msgstr "到达 {0} [{1}]"
 
 msgctxt "path2_wait_at"
 msgid " Wait {0} at {1}"
-msgstr "在 {1} 等待 {0}"
+msgstr "候车 {1} · {0}"
 
 msgctxt "path2_wait_line2"
 msgid " For the departure of {0} [{1}]"
-msgstr "离开 {0} [{1}]"
+msgstr "出发 {0} [{1}]"
 
 msgctxt "path2_walk"
 msgid "Walk for {}"
-msgstr "步行到 {}"
+msgstr "步行 · {}"
 
 msgctxt "pax_new_time"
 msgid "New"


### PR DESCRIPTION
# 修正&优化 行程路线文本

## 修改内容

- 优化：统一使用“·”标识行程或等候时长
- 修正：“Arrive at (车站) / 在 (车站) 到达”更正为“抵达 (车站)”
- 修正：“Walk for (时长) / 步行到 (时长)”更正为“步行 · (时长)”
- 优化：“等待”、“离开”、“直到”更改为更明确的“候车”、“出发”、“到达”
- 优化：适当添加空格以分隔信息

## 修改效果

修改前：

![](https://github.com/user-attachments/assets/4f8081c7-631a-4ba7-b2cf-7181abba12a5)


修改后：

![](https://github.com/user-attachments/assets/011fe047-540b-454c-8efa-da6f7d71a2b4)